### PR TITLE
Remove crawler blocks in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,19 +1,8 @@
+# Let bots crawl everything except /auth and /admin. No special blocks.
 
 User-agent: *
 Allow: /
 Disallow: /auth
 Disallow: /admin
-
-# Block scrapers you don't want
-User-agent: SemrushBot
-Disallow: /
-User-agent: AhrefsBot
-Disallow: /
-User-agent: MJ12bot
-Disallow: /
-User-agent: BLEXBot
-Disallow: /
-User-agent: DotBot
-Disallow: /
 
 Sitemap: https://www.standardthought.com/sitemap_index.xml


### PR DESCRIPTION
## Summary
- let all bots crawl except auth/admin

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e00189ad4832da2e307348dd899dd