### PR TITLE
Fix manual playbook email behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Admin Manual Playbook Send
+
+Admins must enter an email before hitting **Send Playbook** in the dashboard. The tool doesn't fire without a target inbox.

--- a/src/components/manual-send-playbook.tsx
+++ b/src/components/manual-send-playbook.tsx
@@ -7,7 +7,7 @@ import { toast } from "sonner";
 import { manualSendPlaybook } from "@/lib/manual-email-utils";
 
 export const ManualSendPlaybook = () => {
-  const [email, setEmail] = useState("idalmcclure@gmail.com");
+  const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
   const handleSend = async (e: React.FormEvent) => {
@@ -22,7 +22,7 @@ export const ManualSendPlaybook = () => {
     try {
       await manualSendPlaybook(email);
       toast.success(`Playbook sent successfully to ${email}!`);
-      setEmail("idalmcclure@gmail.com");
+      setEmail("");
     } catch (error: any) {
       console.error("Manual send error:", error);
       toast.error(error.message || "Failed to send playbook");


### PR DESCRIPTION
## Summary
- clear manual playbook email state
- wipe email after sending to keep things tidy
- note that admins need to supply an email before triggering the send

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e06bf2d88832d95a632bce3c7e43d