### PR TITLE
Track user last login

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -22,6 +22,7 @@ interface UserProfile {
   role: 'admin' | 'user';
   created_at: string;
   updated_at: string;
+  last_login_at: string | null;
 }
 
 const defaultValue: AuthContextType = {
@@ -98,6 +99,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (process.env.NODE_ENV !== 'production') {
         console.log('Auth state change:', event, session);
       }
+      if (event === 'SIGNED_IN' && session?.user) {
+        await supabase
+          .from('profiles')
+          .update({ last_login_at: new Date().toISOString() })
+          .eq('id', session.user.id);
+      }
       setUser(session?.user ?? null);
       
       if (session?.user) {
@@ -127,10 +134,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const signIn = async (email: string, password: string) => {
     try {
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
       });
+
+      if (!error && data?.user) {
+        await supabase
+          .from('profiles')
+          .update({ last_login_at: new Date().toISOString() })
+          .eq('id', data.user.id);
+      }
+
       return { error };
     } catch (error: unknown) {
       console.error('Sign in error:', error);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -141,6 +141,7 @@ export type Database = {
           id: string
           role: Database["public"]["Enums"]["user_role"] | null
           updated_at: string
+          last_login_at: string | null
         }
         Insert: {
           created_at?: string
@@ -148,6 +149,7 @@ export type Database = {
           id: string
           role?: Database["public"]["Enums"]["user_role"] | null
           updated_at?: string
+          last_login_at?: string | null
         }
         Update: {
           created_at?: string
@@ -155,6 +157,7 @@ export type Database = {
           id?: string
           role?: Database["public"]["Enums"]["user_role"] | null
           updated_at?: string
+          last_login_at?: string | null
         }
         Relationships: []
       }

--- a/supabase/migrations/20250629020000-add-last-login-at.sql
+++ b/supabase/migrations/20250629020000-add-last-login-at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Summary
- add `last_login_at` column via migration
- extend Supabase types to include `last_login_at`
- update auth context to write last login on sign in and auth events

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_686329ac18bc832da85ee07da7835bae