### PR TITLE
Add blog seeder script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ This project is built with:
    - `SUPABASE_SERVICE_ROLE_KEY`
    - `ADMIN_NOTIFICATION_EMAIL`
 
+## Seed the Blog Locally
+
+After your env vars are set, run the seeder to drop in sample posts:
+
+```bash
+npm run seed:blog
+```
+
+You'll get real-looking content in seconds so you can focus on the UI.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/77b99b38-7590-4686-8b21-9653b11d193b) and click on Share -> Publish.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "seed:blog": "ts-node scripts/seed-blog.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/seed-blog.ts
+++ b/scripts/seed-blog.ts
@@ -1,0 +1,14 @@
+// Blog Seeder Runner
+// Purpose: Kick off createSamplePosts from the command line.
+// Why: One command to load the DB with sample posts for local dev.
+import { createSamplePosts } from '../src/lib/sample-posts';
+
+(async () => {
+  const result = await createSamplePosts();
+  if (result.success) {
+    console.log('Blog seeded. Time to build.');
+  } else {
+    console.error('Seed failed:', result.error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a short TS script to populate sample blog posts
- wire up `seed:blog` npm script
- explain the seeder in the README

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_68634c50b004832d8b681ee266374968