### PR TITLE
Refactor admin logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 ## Admin Manual Playbook Send
 
 Admins must enter an email before hitting **Send Playbook** in the dashboard. The tool doesn't fire without a target inbox.
+
+## Set up an admin in Supabase
+
+1. Head to your Supabase project and open the `profiles` table.
+2. Find the user and set their `role` column to `admin`.
+3. Save it. The app picks up the change on next login.
+
+That's it—no more hardcoded emails.

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -156,8 +156,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  // Check if user is admin - either by profile role or by email
-  const isAdmin = profile?.role === 'admin' || user?.email === 'cet3001@gmail.com';
+  // You're an admin if your profile says so. That's it.
+  const isAdmin = profile?.role === 'admin';
 
   if (process.env.NODE_ENV !== 'production') {
     console.log('Current auth state:', { user: user?.email, profile, isAdmin, loading });


### PR DESCRIPTION
## Summary
- check admin based only on `profile.role`
- outline how to set an admin in Supabase

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*

------
https://chatgpt.com/codex/tasks/task_e_68634c4e7384832db9fc06f8c243966d