### PR TITLE
Add override for React versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,9 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"
+  },
+  "overrides": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- lock `react` and `react-dom` using npm `overrides` to ensure version consistency

## Testing
- `npm install`
- `npm run lint` *(fails: ConfigError: Unexpected key "0" found)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6879bac3186c832da2e656c4793a3eed