### PR TITLE
Fix Lovable connection by using env vars

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -43,6 +43,7 @@
   for = "/lovable-uploads/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
+    Access-Control-Allow-Origin = "*"
 
 [[headers]]
   for = "/*.png"

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,13 +1,16 @@
 
 // Supabase Client
-// Purpose: Links our app to Supabase using direct project configuration.
-// Note: Lovable doesn't support VITE_* environment variables, so we use direct URLs.
+// Purpose: Links our app to Supabase. We pull creds from env so Lovable and local dev stay in sync.
 import { createClient } from '@supabase/supabase-js'
 import type { Database } from './types'
 
-// Direct Supabase configuration for Lovable
-const supabaseUrl = 'https://zedewynjmeyhbjysnxld.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InplZGV3eW5qbWV5aGJqeXNueGxkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkwNjQ3OTcsImV4cCI6MjA2NDY0MDc5N30.AHawgYUm8V74I_LoLbU2HUmOwV3A35cvL-QTJ-ZVuyA'
+// Grab credentials from environment. If they aren't set, log a warning.
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL ?? ''
+const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY ?? ''
+
+if (!supabaseUrl || !supabaseKey) {
+  console.warn('Supabase env vars missing. Check VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.')
+}
 
 export const supabase = createClient<Database>(supabaseUrl, supabaseKey, {
   auth: {


### PR DESCRIPTION
## Summary
- source Supabase creds from env vars in `src/integrations/supabase/client.ts`
- allow cross‑origin requests to Lovable uploads via `netlify.toml`

## Testing
- `npm run lint` *(fails: ConfigError)*
- `npm run build`
- `node verify-build.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_6879c2876fb4832d964ffdd516cc6c61